### PR TITLE
Fix Thermaebath fleck positions

### DIFF
--- a/1.5/Source/VFEC/VFEC/Buildings/Thermaebath.cs
+++ b/1.5/Source/VFEC/VFEC/Buildings/Thermaebath.cs
@@ -33,7 +33,7 @@ namespace VFEC.Buildings
             if (this.IsHashIntervalTick(Rand.Range(5, 10)))
             {
                 var rect = this.OccupiedRect();
-                FleckMaker.ThrowAirPuffUp(new Vector3(Rand.Range(rect.minX, rect.maxX), DrawPos.y, Rand.Range(rect.minZ, rect.maxX)), Map);
+                FleckMaker.ThrowAirPuffUp(new Vector3(Rand.Range(rect.minX, rect.maxX + 1f), DrawPos.y, Rand.Range(rect.minZ, rect.maxZ + 1f)), Map);
             }
 
             if (occupants.Count > 5 && this.IsHashIntervalTick(250))


### PR DESCRIPTION
- The flecks were using `maxX` for the Z coordinate's position
- The max fleck position was increased by 1f to fully cover the building
  - `CellRect.RandomVector3` also adds 1f, so the code here will now match it (I haven't used that property as it uses 0 as `Y`)
- The `Rand` now operates on floats rather than ints, so the flecks can now spawn at non-integer positions