### PR TITLE
Fixes and improvements to perk system

### DIFF
--- a/1.5/Source/VFEC/VFEC/Perks/GameComponent_PerkManager.cs
+++ b/1.5/Source/VFEC/VFEC/Perks/GameComponent_PerkManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Verse;
+using VFEC.Senators;
 
 namespace VFEC.Perks
 {
@@ -53,6 +54,12 @@ namespace VFEC.Perks
         public override void ExposeData()
         {
             base.ExposeData();
+            // Remove the perk for uniting the republics if extra factions through faction
+            // discovery were added and now the republics aren't united anymore.
+            if (Scribe.mode == LoadSaveMode.Saving)
+                foreach (var republicDef in DefDatabase<RepublicDef>.AllDefs)
+                    if (ActivePerks.Contains(republicDef.perk) && !republicDef.United)
+                        RemovePerk(republicDef.perk);
             Scribe_Collections.Look(ref ActivePerks, "activePerks", LookMode.Def);
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
                 foreach (var perk in ActivePerks)

--- a/1.5/Source/VFEC/VFEC/Senators/SenatorUIUtility.cs
+++ b/1.5/Source/VFEC/VFEC/Senators/SenatorUIUtility.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Linq;
+using HarmonyLib;
 using RimWorld;
 using UnityEngine;
 using Verse;
@@ -21,7 +22,11 @@ public static class SenatorUIUtility
 
     public static void DoPerkButton()
     {
-        if (Widgets.ButtonText(new Rect(0, 10f, 120f, 30f), "View Perks")) Find.WindowStack.Add(new Dialog_PerkInfo());
+        var anyPerk = DefDatabase<RepublicDef>.AllDefs
+            .Any(republicDef => republicDef.parts
+                .Any(factionDef => Find.FactionManager.FirstFactionOfDef(factionDef) != null));
+
+        if (anyPerk && Widgets.ButtonText(new Rect(0, 10f, 120f, 30f), "VFEC.UI.ViewPerks".Translate())) Find.WindowStack.Add(new Dialog_PerkInfo());
     }
 
     public static void DoSenatorInfoButton(Faction faction, ref Rect fillRect, float rowY)
@@ -29,7 +34,7 @@ public static class SenatorUIUtility
         if (faction.ShouldHaveSenators())
         {
             fillRect.width -= 130f;
-            if (Widgets.ButtonText(new Rect(fillRect.width + 5f, rowY + 25f, 120f, 30f), "View Senators"))
+            if (Widgets.ButtonText(new Rect(fillRect.width + 5f, rowY + 25f, 120f, 30f), "VFEC.UI.ViewSenators".Translate()))
             {
                 WorldComponent_Senators.Instance.CheckInit();
                 Find.WindowStack.Add(new Dialog_SenatorInfo(faction.def.GetModExtension<FactionExtension_SenatorInfo>(),

--- a/1.5/Source/VFEC/VFEC/Senators/WorldComponent_Senators.cs
+++ b/1.5/Source/VFEC/VFEC/Senators/WorldComponent_Senators.cs
@@ -294,12 +294,23 @@ public class RepublicDef : Def
     public List<FactionDef> parts;
     public PerkDef perk;
 
-    public bool United => WorldComponent_Senators.Instance is not null && parts.All(part =>
+    public bool United
     {
-        var faction = Find.FactionManager?.FirstFactionOfDef(part);
-        if (faction is null) return false;
-        return WorldComponent_Senators.Instance.Permanent.TryGetValue(faction, out var perm) && perm;
-    });
+        get
+        {
+            if (WorldComponent_Senators.Instance == null || Find.FactionManager == null)
+                return false;
+
+            var activeFactions = parts
+                    .Select(part => Find.FactionManager.FirstFactionOfDef(part))
+                    .Where(faction => faction != null)
+                    .ToList();
+
+            // True if there's at least 1 faction and all the factions are united
+            return activeFactions.Any() &&
+                   activeFactions.All(faction => WorldComponent_Senators.Instance.Permanent.TryGetValue(faction, out var perm) && perm);
+        }
+    }
 }
 
 public class SenatorInfo : IExposable

--- a/Languages/English/Keyed/UI.xml
+++ b/Languages/English/Keyed/UI.xml
@@ -13,4 +13,6 @@ Gain support of all the senators to unlock unique perks and eventually unite the
     <VFEC.UI.NotEnoughMoney>You do not have enough money with you to do this.</VFEC.UI.NotEnoughMoney>
     <VFEC.UI.BribeReject>{0} has rejected your bribe and can no longer be bribed.</VFEC.UI.BribeReject>
     <VFEC.UI.AlreadyQuest>Already have a quest for that senator.</VFEC.UI.AlreadyQuest>
+    <VFEC.UI.ViewPerks>View Perks</VFEC.UI.ViewPerks>
+    <VFEC.UI.ViewSenators>View Senators</VFEC.UI.ViewSenators>
 </LanguageData>


### PR DESCRIPTION
- The perk for unifying all the republics will now unlock when all the republics present in the current game are unified
  - This means that you can still get the final perk if you play with 1/2 republics rather than 3
  - If you add the missing republics (through faction discovery) then the final perk will be re-locked next time the game is saved (until you unify the new factions as well)
    - It would be possible to add the re-locking code in the code spawning a new faction, but I wanted to keep it simple and avoid any unnecessary Harmony patches
- The button to open perk info dialog is hidden if there's no republics present in the game
  - It should become visible again once you add them using faction discovery
- Fixed errors with perk info dialog when not all factions are spawned in the game
- Perk info dialog will now update its data while open in case you finish any of the quests while it's open
  - This means that you don't need to re-open the dialog to see perks becoming unlocked/re-locked
- The size of perk info dialog is now slightly bigger to take into consideration the close button size
  - The close button was slightly overlapping with the perks with only 1/2 active republics
- "View Perks" and "View Senators" text is no longer hardcoded and is now defined in the `UI.xml` language file
- Simplified the `info` list for perk info dialog
  - It takes more space due to use of multiple classes, but it should be easier to understand what the code does