### PR TITLE
Add extra research restrictions to Profectus perk

### DIFF
--- a/1.5/Source/VFEC/VFEC/Perks/Workers/Profectus.cs
+++ b/1.5/Source/VFEC/VFEC/Perks/Workers/Profectus.cs
@@ -31,7 +31,7 @@ namespace VFEC.Perks.Workers
 
         private void DoResearch()
         {
-            if (DefDatabase<ResearchProjectDef>.AllDefs.Where(proj => proj.TechprintCount <= 0 && proj.CanStartNow).TryRandomElement(out var research))
+            if (DefDatabase<ResearchProjectDef>.AllDefs.Where(CanResearch).TryRandomElement(out var research))
             {
                 Find.ResearchManager.FinishProject(research);
                 var faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_EasternRepublic);
@@ -45,6 +45,13 @@ namespace VFEC.Perks.Workers
             else
                 nextResearchTick = Find.TickManager.TicksGame + 60000; // Check each day for new research
         }
+
+        private static bool CanResearch(ResearchProjectDef proj) =>
+            proj.TechprintCount <= 0 &&
+            proj.RequiredAnalyzedThingCount <= 0 &&
+            !proj.requiresMechanitor &&
+            proj.knowledgeCategory == null &&
+            proj.CanStartNow;
 
         public override void ExposeData()
         {


### PR DESCRIPTION
I've changed the Profectus code to no longer pick:
- Any Anomaly research
- Any research that needs mechanitor
- Any research that requires analyzing an item

On top of that I've extracted the check into a separate method. With the now longer condition this should be cleaner to read. It should also allow other mods to add their own restrictions by adding a Harmony patch.

The restriction to mechanitor pawn and researching items were added to match the (likely) intent of techprint requirement - the republic won't research something based on stuff you yourself did, like you applying techprints or analyzing objects, as they themselves most likely have no access to it.