### PR TITLE
Improvements to reinforcements code

### DIFF
--- a/1.5/Source/VFEC/VFEC/Buildings/Beacon.cs
+++ b/1.5/Source/VFEC/VFEC/Buildings/Beacon.cs
@@ -25,16 +25,93 @@ public class Beacon : Building, ISizeReporter
 
     private Faction GetFaction()
     {
-        var faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_WesternRepublic);
-        if (faction.PlayerRelationKind == FactionRelationKind.Ally) return faction;
+        var factions = GetFactionsInReinforcementOrder().ToList();
+        // Find an allied faction that is hostile to player enemies.
+        var faction = factions.FirstOrDefault(f => CanFactionReinforce(f, out _));
+        // If no faction was found, repeat but skip the check for hostiles.
+        // Do this in case our check for hostiles failed.
+        faction ??= factions.FirstOrDefault(f => CanFactionReinforce(f, out _, false));
 
-        faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_CentralRepublic);
-        if (faction.PlayerRelationKind == FactionRelationKind.Ally) return faction;
-
-        faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_EasternRepublic);
-        if (faction.PlayerRelationKind == FactionRelationKind.Ally) return faction;
-        faction = Find.FactionManager.RandomAlliedFaction();
         return faction;
+    }
+
+    private string GetFactionUnavailableReasons(bool checkForHostiles = true)
+    {
+        var factions = GetFactionsInReinforcementOrder()
+            .Select(f => (canReinforce: CanFactionReinforce(f, out var reason, checkForHostiles), reason))
+            .ToList();
+
+        // Return null, there's an ally available
+        if (factions.Any(x => x.canReinforce))
+            return null;
+        // No allies available at all
+        if (factions.All(x => x.reason.NullOrEmpty()))
+            return "VFEC.NoAllies".Translate();
+
+        // List all reasons allies can't arrive (in alphabetical order to avoid flickering tooltips).
+        var reasons = factions
+            .SelectMany(x => x.reason)
+            .Distinct()
+            .Select(x => x.TranslateSimple())
+            .OrderBy(x => x)
+            .ToCommaList()
+            .CapitalizeFirst();
+        return $"{"VFEC.NoReinforce".Translate()} ({reasons}.)";
+    }
+
+    private IEnumerable<Faction> GetFactionsInReinforcementOrder()
+    {
+        // List of all the republics in other they should reinforce.
+        // Used to iterate over it and exclude from non-republic faction search.
+        var republics = new[]
+        {
+            VFEC_DefOf.VFEC_WesternRepublic,
+            VFEC_DefOf.VFEC_CentralRepublic,
+            VFEC_DefOf.VFEC_EasternRepublic,
+        };
+
+        // Go through all republics
+        foreach (var factionDef in republics)
+        {
+            var faction = Find.FactionManager.FirstFactionOfDef(factionDef);
+            if (faction != null)
+                yield return faction;
+        }
+
+        // Go through all other valid factions in random order
+        foreach (var f in Find.FactionManager.GetFactions().Where(f => !republics.Contains(f.def)).InRandomOrder())
+            yield return f;
+    }
+
+    private bool CanFactionReinforce(Faction faction, out List<string> reason, bool checkForHostiles = true)
+    {
+        reason = new List<string>();
+
+        // Make sure allied, and don't report any reasons
+        if (faction.PlayerRelationKind != FactionRelationKind.Ally)
+            return false;
+
+        // Make sure that the allies can arrive based on the map temperature
+        if (!faction.def.allowedArrivalTemperatureRange.ExpandedBy(4f).Includes(Map.mapTemperature.SeasonalTemp))
+            reason.Add("BadTemperature");
+
+        // Make sure there's no lord preventing reinforcements
+        if (NeutralGroupIncidentUtility.AnyBlockingHostileLord(Map, faction))
+            reason.Add("HostileVisitorsPresent");
+
+        if (checkForHostiles)
+        {
+            var anyHostiles = Map.attackTargetsCache.TargetsHostileToColony
+                .Where(GenHostility.IsActiveThreatToPlayer)
+                .Select(x => ((Thing)x)?.Faction)
+                .Any(x => x != null && x.HostileTo(faction));
+            // Make sure there's any hostiles on the map
+            if (!anyHostiles)
+                reason.Add("VFEC.NoHostiles");
+        }
+
+        // If the list is empty then the faction can reinforce
+        return reason.Empty();
     }
 
     public override void SpawnSetup(Map map, bool respawningAfterLoad)
@@ -59,7 +136,7 @@ public class Beacon : Building, ISizeReporter
         };
 
         if (!mapComp.CanLightBeacon()) command.Disable("VFEC.Cooldown".Translate());
-        else if (GetFaction() is null) command.Disable("VFEC.NoAllies".Translate());
+        else if (GetFactionUnavailableReasons(false) is { } reason) command.Disable(reason);
         // else if (!IncidentDefOf.RaidFriendly.Worker.CanFireNow(GetIncidentParms())) command.Disable("VFEC.NoReinforce".Translate());
 
         return command;
@@ -124,7 +201,9 @@ public class MapComponent_Beacon : MapComponent
     public const int BEACON_COOLDOWN = 180000;
     private int lastBeaconTick = -BEACON_COOLDOWN * 2;
 
-    public MapComponent_Beacon(Map map) : base(map) { }
+    public MapComponent_Beacon(Map map) : base(map)
+    {
+    }
 
     public void Notify_BeaconLit()
     {

--- a/1.5/Source/VFEC/VFEC/Perks/Workers/Auxilia.cs
+++ b/1.5/Source/VFEC/VFEC/Perks/Workers/Auxilia.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using HarmonyLib;
 using RimWorld;
 using Verse;
@@ -18,10 +19,34 @@ namespace VFEC.Perks.Workers
 
         public static void DoSupportLegion(IncidentWorker_RaidEnemy __instance, IncidentParms parms, ref bool __result)
         {
-            if (__result && Rand.Chance(0.25f))
+            if (__result && parms.target is Map map && Rand.Chance(0.25f))
             {
-                parms.faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_WesternRepublic);
-                __result = __result && IncidentDefOf.RaidFriendly.Worker.TryExecute(parms);
+                var faction = Find.FactionManager.FirstFactionOfDef(VFEC_DefOf.VFEC_WesternRepublic);
+                if (faction.HostileTo(parms.faction))
+                {
+                    var reasons = new List<string>();
+
+                    if (!faction.def.allowedArrivalTemperatureRange.ExpandedBy(4f).Includes(map.mapTemperature.SeasonalTemp))
+                        reasons.Add("BadTemperature");
+                    if (NeutralGroupIncidentUtility.AnyBlockingHostileLord(map, faction))
+                        reasons.Add("HostileVisitorsPresent");
+
+                    // Spawn the support legion if nothing is blocking it
+                    if (reasons.Empty())
+                    {
+                        parms.faction = faction;
+                        __result = __result && IncidentDefOf.RaidFriendly.Worker.TryExecute(parms);
+                    }
+                    // List the reason the support legion can't spawn
+                    else
+                    {
+                        var reasonsText = reasons
+                            .Select(x => x.TranslateSimple())
+                            .OrderBy(x => x)
+                            .ToCommaList();
+                        Messages.Message("VFEC.ReinforcementLegionFailed".Translate(reasonsText), MessageTypeDefOf.NeutralEvent);
+                    }
+                }
             }
         }
     }

--- a/Languages/English/Keyed/Misc.xml
+++ b/Languages/English/Keyed/Misc.xml
@@ -12,6 +12,9 @@
     <VFEC.Cooldown>Still on cooldown.</VFEC.Cooldown>
     <VFEC.NoAllies>No allies.</VFEC.NoAllies>
     <VFEC.NoReinforce>No reinforcements available.</VFEC.NoReinforce>
+    <!-- Text capitalized in code, since it may be in the middle of a sentence. -->
+    <VFEC.NoHostiles>allies have no hostiles</VFEC.NoHostiles>
+    <VFEC.ReinforcementLegionFailed>Reinforcement legion is unable to assist: {0}.</VFEC.ReinforcementLegionFailed>
     <VFEC.LightTheBeacon.Desc>Light this beacon to call reinforcements.</VFEC.LightTheBeacon.Desc>
     <VFEC.BuildingRoad>Building road: {0}, progress: {1}, ({2}/{3})</VFEC.BuildingRoad>
     <VFEC.RoadFinished>{0} has finished building {1}</VFEC.RoadFinished>


### PR DESCRIPTION
Code related to reinforcements from Auxilia perk and Beacon building has been improved:
- Auxilia and Beacon won't spawn reinforcements based on specific map conditions
  - Beacon will keep checking every possible allied faction until it can find one that it can spawn, if any
  - Auxilia will cause a message to pop-up with a reason why they weren't able to reinforce
- Reinforcements now check if they are friendly with the faction attacking the player
  - Auxilia reinforcements won't arrive if friendly with player enemies
  - Beacon will try to spawn reinforcements that are hostile to the threat, if any
- Reinforcements cannot arrive if out of allowed arrival temperature range for the faction
- Reinforcements cannot arrive if there are other visitors blocking their arrival
  - For example, reinforcements cannot arrive from a faction that is hostile to the Empire while you're hosting the bestowing ceremony
- Beacon will now work even if republic factions are disabled
- Auxilia should no longer have the reinforcements steal or kidnap pawns, along with other weirdness like potential biocoded weapons and apparel, among other things
  - This was achieved by creating IncidentParms from scratch, rather than re-using the ones from current raid
- Auxilia will no longer modify the result of raid spawn
  - Modifying the result would, at that point, not prevent the raid - just stop a bunch of code from being notified that it happened
- A warning will be logged if reinforcements from Auxilia will fail to spawn