### PR TITLE
Improve and fix thought related perks

### DIFF
--- a/1.5/Defs/PerkDefs/Perks.xml
+++ b/1.5/Defs/PerkDefs/Perks.xml
@@ -28,7 +28,10 @@
         <defName>PanemEtCircenses</defName>
         <description>All positive mood thoughts last 20% longer.</description>
         <texPath>UI/Perks/Perk_PanemEtCircenses</texPath>
-        <workerClass>VFEC.Perks.Workers.Panem</workerClass>
+        <workerClass>VFEC.Perks.Workers.PlayerOnly</workerClass>
+        <statFactors>
+            <VEF_PositiveThoughtDurationFactor>1.2</VEF_PositiveThoughtDurationFactor>
+        </statFactors>
     </VFEC.Perks.PerkDef>
     <VFEC.Perks.PerkDef>
         <label>Ars Longa, Vita Brevis</label>
@@ -45,7 +48,10 @@
         <defName>ExitusActaProbat</defName>
         <description>All negative mood thoughts last 10% shorter.</description>
         <texPath>UI/Perks/Perk_ExitusActaProbat</texPath>
-        <workerClass>VFEC.Perks.Workers.Exitus</workerClass>
+        <workerClass>VFEC.Perks.Workers.PlayerOnly</workerClass>
+        <statFactors>
+            <VEF_NegativeThoughtDurationFactor>0.9</VEF_NegativeThoughtDurationFactor>
+        </statFactors>
     </VFEC.Perks.PerkDef>
     <VFEC.Perks.PerkDef>
         <label>Alea Iacta Est</label>

--- a/1.5/Source/VFEC/VFEC/Perks/ThoughtWorkers_Patched.cs
+++ b/1.5/Source/VFEC/VFEC/Perks/ThoughtWorkers_Patched.cs
@@ -7,13 +7,13 @@ namespace VFEC.Perks
     {
         private PerkDef perk;
         public PerkDef Perk => perk ??= def.GetModExtension<PerkExtension>().perk;
-        public override float MoodMultiplier(Pawn p) => GameComponent_PerkManager.Instance.ActivePerks.Contains(Perk) ? 0.5f : 1f;
+        public override float MoodMultiplier(Pawn p) => p.Faction is { IsPlayer: true } && GameComponent_PerkManager.Instance.ActivePerks.Contains(Perk) ? 0.5f : 1f;
     }
 
     public class ThoughtWorker_Cold_Patched : ThoughtWorker_Cold
     {
         private PerkDef perk;
         public PerkDef Perk => perk ??= def.GetModExtension<PerkExtension>().perk;
-        public override float MoodMultiplier(Pawn p) => GameComponent_PerkManager.Instance.ActivePerks.Contains(Perk) ? 0.5f : 1f;
+        public override float MoodMultiplier(Pawn p) => p.Faction is { IsPlayer: true } && GameComponent_PerkManager.Instance.ActivePerks.Contains(Perk) ? 0.5f : 1f;
     }
 }

--- a/1.5/Source/VFEC/VFEC/Perks/Workers/AffectMemories.cs
+++ b/1.5/Source/VFEC/VFEC/Perks/Workers/AffectMemories.cs
@@ -15,8 +15,8 @@ namespace VFEC.Perks.Workers
 
         public override IEnumerable<Patch> GetPatches()
         {
-            yield return Patch.Prefix(
-                AccessTools.Method(typeof(MemoryThoughtHandler), nameof(MemoryThoughtHandler.TryGainMemory), new[] {typeof(Thought_Memory), typeof(Pawn)}),
+            yield return Patch.Postfix(
+                AccessTools.Method(typeof(MemoryThoughtHandler), nameof(MemoryThoughtHandler.TryGainMemory), new[] { typeof(Thought_Memory), typeof(Pawn) }),
                 AccessTools.Method(GetType(), nameof(DoEffects))
             );
         }
@@ -27,32 +27,6 @@ namespace VFEC.Perks.Workers
         }
 
         public abstract void DoEffect(Thought_Memory newThought);
-    }
-
-    public class Panem : AffectMemories
-    {
-        public Panem(PerkDef def) : base(def)
-        {
-        }
-
-        public override void DoEffect(Thought_Memory newThought)
-        {
-            if (newThought.CurStage.baseMoodEffect > 0)
-                newThought.durationTicksOverride = Mathf.RoundToInt(newThought.DurationTicks * 1.2f);
-        }
-    }
-
-    public class Exitus : AffectMemories
-    {
-        public Exitus(PerkDef def) : base(def)
-        {
-        }
-
-        public override void DoEffect(Thought_Memory newThought)
-        {
-            if (newThought.CurStage.baseMoodEffect < 0)
-                newThought.durationTicksOverride = Mathf.RoundToInt(newThought.DurationTicks * 0.9f);
-        }
     }
 
     [StaticConstructorOnStartup]
@@ -71,7 +45,9 @@ namespace VFEC.Perks.Workers
             ThoughtDefOf.WitnessedDeathAlly,
             ThoughtDefOf.WitnessedDeathNonAlly,
             ThoughtDefOf.WitnessedDeathFamily,
-            ThoughtDefOf.KnowColonistDied
+            ThoughtDefOf.KnowColonistDied,
+            // For testing purposes
+            ThoughtDefOf.DebugBad,
         };
 
         static Morituri()
@@ -93,7 +69,7 @@ namespace VFEC.Perks.Workers
 
         public override void DoEffect(Thought_Memory newThought)
         {
-            if (ToEffect.Contains(newThought.def))
+            if (newThought.pawn.Faction is { IsPlayer: true } && newThought.moodOffset <= 0 && ToEffect.Contains(newThought.def))
                 newThought.moodPowerFactor *= 0.5f;
         }
     }


### PR DESCRIPTION
- Fixed the infinite loading of labyrinth maps as well as some other bugs related to perks affecting mood duration
- Perks affecting mood duration now use a new VEF StatDef
- Perks affecting mood in any capacity now only apply to player faction only, rather than all factions
- `Nos Morituri Te Salutant` is no longer applied if the mood would be positive
  - Just making sure that if there's any trait or anything modifying the mood to be a positive one we won't decrease its duration
- For testing purposes, `Nos Morituri Te Salutant` now also affects "Debug bad thought"

Changes to use the new VEF StatDef rely on Vanilla-Expanded/VanillaExpandedFramework#120