### PR TITLE
Fix senator quests generating with 0 threat points

### DIFF
--- a/1.5/Source/VFEC/VFEC/Senators/SenatorQuests.cs
+++ b/1.5/Source/VFEC/VFEC/Senators/SenatorQuests.cs
@@ -71,7 +71,8 @@ public static class SenatorQuests
         faction.leader = pawn;
         info = new SenatorInfoWithFaction { Info = senatorInfo, Faction = faction };
         var slate = new Slate();
-        slate.Set("asker", pawn);
+        slate.Set(SlateNames.Asker, pawn);
+        slate.Set(SlateNames.Points, StorytellerUtility.DefaultSiteThreatPointsNow());
         var quest = QuestGen.Generate(ValidQuests.Where(root => root.CanRun(slate)).RandomElement(), slate);
         info = null;
         faction.leader = leader;


### PR DESCRIPTION
Looks like the senator quests didn't specify amount of threat points to generate with, thus ending up in the default value of 0 being used for them all. This resulted in quests basically always generating with a single enemy defending the quest.

I've changed the quest generation to include points. I've used `StorytellerUtility.DefaultSiteThreatPointsNow()`, as it uses the world threat points and scales them to appropriate site threat points.

On top of that, I've replaced the use of `asker` string in the slate with using the constant of `SlateNames.Asker`. This should ensure that it's always correct, nobody accidentally modifies it, or any similar situations like those.